### PR TITLE
Remove Partial<> for required attributes

### DIFF
--- a/packages/prisma-factory/src/generator/factories.ts
+++ b/packages/prisma-factory/src/generator/factories.ts
@@ -32,7 +32,7 @@ function addModelFactoryFunction(
   newFunction.insertParameters(0, [
     {
       name: 'requiredAttrs',
-      type: `ObjectWithMaybeCallbacks<Partial<Prisma.${model.name}CreateInput>>`,
+      type: `ObjectWithMaybeCallbacks<Prisma.${model.name}CreateInput>`,
       hasQuestionToken: true,
     },
   ]);


### PR DESCRIPTION
First off, really like this factory tool!

I noticed whilst coding that VSCode was not warning me of errors when using the `create...Factory` functions and saw that the generated files wrap all the inputs like `Partial<...Input>`. Any reason to go with wrapping the input type with a `Partial`? If there, would be happy to make it an option in the generator config instead of removing it completely.