### PR TITLE
chore: updates prisma peer dependency to allow version 3 or greater

### DIFF
--- a/.changeset/tiny-otters-repeat.md
+++ b/.changeset/tiny-otters-repeat.md
@@ -1,0 +1,5 @@
+---
+'prisma-factory': patch
+---
+
+Updates prisma peer dependency to support version 3 or greater

--- a/packages/prisma-factory/package.json
+++ b/packages/prisma-factory/package.json
@@ -55,7 +55,7 @@
     "test:coverage": "jest --coverage"
   },
   "peerDependencies": {
-    "@prisma/client": "^3.11.0",
+    "@prisma/client": ">=3.0.0",
     "typescript": ">4.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes peer dependency warnings when using Prisma 4.