### PR TITLE
Allow dates to be passed in as default values to factories

### DIFF
--- a/packages/prisma-factory/src/utils/getAttrs.ts
+++ b/packages/prisma-factory/src/utils/getAttrs.ts
@@ -1,9 +1,16 @@
 import type { ObjectWithMaybeCallbacks } from '../lib/types';
 
+const isNestedObject = (value: unknown): boolean => {
+  if (value instanceof Date) {
+    return false;
+  }
+  return typeof value === 'object';
+};
+
 export const getAttrs = <T>(attrs: ObjectWithMaybeCallbacks<T>): T => {
   return Object.fromEntries(
     Object.entries(attrs).map(([key, value]) => {
-      if (typeof value === 'object') {
+      if (isNestedObject(value)) {
         // recursively evaluate nested objects
         return [key, getAttrs(value as ObjectWithMaybeCallbacks<T[keyof T]>)];
       }
@@ -11,7 +18,7 @@ export const getAttrs = <T>(attrs: ObjectWithMaybeCallbacks<T>): T => {
       if (typeof value === 'function') {
         const result = value();
 
-        if (typeof result === 'object') {
+        if (isNestedObject(result)) {
           // recursively evaluate nested objects
           return [key, getAttrs(result as ObjectWithMaybeCallbacks<T[keyof T]>)];
         }


### PR DESCRIPTION
This fixes this issue:

https://github.com/echobind/prisma-factory/issues/13

and lets us use dates and functions that return dates as defaults in our factories.