### PR TITLE
fix: add "generated" option in package.json's exports field

### DIFF
--- a/packages/prisma-factory/package.json
+++ b/packages/prisma-factory/package.json
@@ -28,6 +28,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./generated": {
+      "types": "./generated/index.d.ts",
+      "import": "./generated/index.js",
+      "require": "./generated/index.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.mjs",


### PR DESCRIPTION
I'm using this package on a fastify, prisma and node-tap project and it gives me this error: `Error: Cannot find module '..../node_modules/prisma-factory/dist/generated.js'`.

I've noticed that in prisma-factory's pacakge.json is defined the "exports" field. In particular, the `"./*"` option is causing this error, since the `import {...} from "prisma-factory/generated"` will be redirected to the `dist` folder. So I've added an option for the "generated" folder to point to the correct file, solving the problem.

P.S.: I'm using pnpm as package manager.

fixes #17 